### PR TITLE
[fix] 지난학습결과수정

### DIFF
--- a/src/main/java/com/babyhands/dto/SignQuestionResult.java
+++ b/src/main/java/com/babyhands/dto/SignQuestionResult.java
@@ -7,6 +7,7 @@ import lombok.*;
 @AllArgsConstructor
 @Builder
 public class SignQuestionResult {
+	private Long slTestId;
     private int slId;
     private String jamo;        // 내가 고른 답 (CHOOSE_ANSWER)
     private String correctJamo; // 정답 (SIGN_LANGUAGE.MEANING)

--- a/src/main/resources/mybatis/mapper/SlTestMapper.xml
+++ b/src/main/resources/mybatis/mapper/SlTestMapper.xml
@@ -136,21 +136,22 @@
     WHERE MEMBER_ID = #{memberId}
   </select>
 
-  <!-- 2) 최신 그룹의 문항별 결과 (내답/정답/정오) -->
-  <select id="selectQuestionResultsByGroup"
-          parameterType="map"
-          resultType="com.babyhands.dto.SignQuestionResult">
-    SELECT
-      t.SL_ID                 AS slId,
-      t.CHOOSE_ANSWER         AS jamo,         -- 내가 고른 답
-      s.MEANING               AS correctJamo,  -- 정답
-      CASE WHEN s.MEANING = t.CHOOSE_ANSWER THEN 1 ELSE 0 END AS isCorrect
-    FROM SL_TEST t
-    JOIN SIGN_LANGUAGE s ON s.SL_ID = t.SL_ID
-    WHERE t.MEMBER_ID = #{memberId}
-      AND t.SL_TEST_GROUP = #{groupNo}
-    ORDER BY t.SL_TEST_DATE
-  </select>
+<!-- 2) 최신 그룹의 문항별 결과 (내답/정답/정오) -->
+<select id="selectQuestionResultsByGroup"
+        parameterType="map"
+        resultType="com.babyhands.dto.SignQuestionResult">
+  SELECT
+    t.SL_TEST_ID           AS slTestId,      -- ★ 추가: 입력 순서 키
+    t.SL_ID                AS slId,
+    t.CHOOSE_ANSWER        AS jamo,          -- 내가 고른 답
+    s.MEANING              AS correctJamo,   -- 정답
+    CASE WHEN s.MEANING = t.CHOOSE_ANSWER THEN 1 ELSE 0 END AS isCorrect
+  FROM SL_TEST t
+  JOIN SIGN_LANGUAGE s ON s.SL_ID = t.SL_ID
+  WHERE t.MEMBER_ID = #{memberId}
+    AND t.SL_TEST_GROUP = #{groupNo}
+  ORDER BY t.SL_TEST_ID ASC                  -- ★ 핵심: 입력 순서 보장
+</select>
 
   <!-- 3) 최신 그룹 요약 (정답 수 / 총 문항 / 총 점수) -->
   <select id="selectSummaryByGroup"


### PR DESCRIPTION
## 요약
지난학습결과 문제 순서가 내가 고른 순서와 다르게 나오는 현상을 수정


## 변경 유형
- [ ] feat (새 기능)
- [x] fix (버그 수정)
- [ ] refactor (리팩터)
- [ ] perf (성능 개선)
- [ ] chore (빌드/도구/의존성)
- [ ] docs (문서)
- [ ] test (테스트 추가/수정)
- [ ] style (포맷/네이밍 등 비기능 변경)
- [ ] ci (CI/CD)

## 상세 내용
지난 학습결과 문제 순서가 내가 고른 순서와 다르게 나오는 현상을 수정했습니다
